### PR TITLE
removed extra darkmode button

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -125,10 +125,6 @@ export default function Navbar() {
                 Submit Recipe
               </button>
             </Link>
-
-            <div className="flex justify-end pt-4">
-              <DarkMode/>
-            </div>
           </div>
         )}
       </div>


### PR DESCRIPTION
fixes #32 

Removed extra darkmode button that was appearing on reducing screen size

Before :- 

![image](https://github.com/user-attachments/assets/1b443baa-d000-432c-a813-87c77b02a939)

After :- 

![image](https://github.com/user-attachments/assets/2287d89f-2360-4a7d-bdcd-9138d8c8a9b3)
